### PR TITLE
added snippet for one of common DOM method `createDocumentFragment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,7 @@ All notable changes to the "dom-code-snippets" extension will be documented in t
 ## [1.0.2]
 
 - Added **dce** for document.createElement
+
+## [1.0.3]
+
+- Added **cdf** shortcut for document.createDocumentFragment snippet

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Below is a list of all snippets. The **→** means the `TAB` key.
 |  `dqs→` | `const var = document.querySelector('selector');`    |
 |  `dqa→` | `const var = document.querySelectorAll('selector');` |
 |  `dce→` | `const var = document.createElement('element');`     |
+|  `cdf→` | `const var = document.createDocumentFragment();`     |
 
 ---
 

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -18,5 +18,10 @@
     "prefix": "dce",
     "body": "const ${1:varName} = document.createElement('${2:elementName}');${0}",
     "description": "Creates an element using document.createElement"
+  },
+  "createDocumentFragment": {
+    "prefix": "cdf",
+    "body": "const ${1:varName} = document.createDocumentFragment();${0}",
+    "description": "Creates an element using document.createDocumentFragment"
   }
 }


### PR DESCRIPTION
Hi,
I have added a snippet for common DOM method `document.createDocumentFragment()` which is helping when we need to create multiple html element and append them altogether.  for eg *li* of a *ul*